### PR TITLE
Extend NetCDF convention capabilities

### DIFF
--- a/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/ucar/VariableWrapper.java
+++ b/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/ucar/VariableWrapper.java
@@ -124,7 +124,12 @@ final class VariableWrapper extends Variable {
      */
     @Override
     public String getDescription() {
-        return variable.getDescription();
+        String d = variable.getDescription();
+        if (d != null && (d = d.trim()).isEmpty()) {
+            d = null;
+        }
+
+        return d;
     }
 
     /**

--- a/storage/sis-netcdf/src/main/java/org/apache/sis/storage/netcdf/GridResource.java
+++ b/storage/sis-netcdf/src/main/java/org/apache/sis/storage/netcdf/GridResource.java
@@ -270,6 +270,13 @@ final class GridResource extends AbstractGridResource implements ResourceOnFileS
         return UnmodifiableArrayList.wrap(ranges);
     }
 
+    /**
+     * Try to add information about valid values in a given sample dimension builder.
+     * 
+     * @param target The builder to add information into.
+     * @param range Base range for valid values.
+     * @param data Variable to use in order to improve quantitative information.
+     */
     private void addQuantitativeInfo(final SampleDimension.Builder target, NumberRange<?> range, final Variable data) {
         final TransferFunction tr = convention.getTransferFunction(data);
         final MathTransform1D mt = tr.getTransform();


### PR DESCRIPTION
Hi,

The aim is to add methods in convention to allow better discovering of sample dimensions of a NetCDF with an arbitrary convention.
There's also a little workaround for blank variable descriptions when using ucar wrapper.

Hope it helps ;)