### PR TITLE
refactor(Storage): minor rework of error management upon datastore discovery

### DIFF
--- a/storage/sis-storage/src/test/java/org/apache/sis/storage/FailingProvider.java
+++ b/storage/sis-storage/src/test/java/org/apache/sis/storage/FailingProvider.java
@@ -1,0 +1,35 @@
+package org.apache.sis.storage;
+
+import org.apache.sis.internal.storage.URIDataStore;
+import org.opengis.parameter.ParameterDescriptorGroup;
+
+public class FailingProvider extends DataStoreProvider {
+
+    private static final String NAME = "ALWAYS_FAIL";
+
+    @Override
+    public String getShortName() {
+        return NAME;
+    }
+
+    @Override
+    public ParameterDescriptorGroup getOpenParameters() {
+        return URIDataStore.Provider.descriptor(NAME);
+    }
+
+    @Override
+    public ProbeResult probeContent(StorageConnector connector) throws DataStoreException {
+        throw new SystematicFailure("I always fail. I'm here to ensure Datastore discovery is robust to arbitrary provider errors");
+    }
+
+    @Override
+    public DataStore open(StorageConnector connector) throws DataStoreException {
+        throw new UnsupportedOperationException("Not meant to be supported");
+    }
+
+    public static class SystematicFailure extends RuntimeException {
+        SystematicFailure(String message) {
+            super(message);
+        }
+    }
+}

--- a/storage/sis-storage/src/test/resources/META-INF/services/org.apache.sis.storage.DataStoreProvider
+++ b/storage/sis-storage/src/test/resources/META-INF/services/org.apache.sis.storage.DataStoreProvider
@@ -1,0 +1,1 @@
+org.apache.sis.storage.FailingProvider


### PR DESCRIPTION
With both various possible input format and drivers, it is very complicated to ensure that content probing never launch unexpected errors. To mitigate such problem, we modify current fail-fast strategy to try other providers before raising errors.

This has multiple advantages: 
1. Instead of getting one error at once, if multiple providers are unstable, a report with all catched errors is returned at once, allowing to spot multiple bugs (and therefore, allow to fix them) at once. 
2. Also, if an unstable provider cause an error, the operation can still succeed if the required provider is tested after the failing one.