### PR TITLE
fix(NetCDF): Ignore unrecognized dimensions

### DIFF
--- a/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/FeatureSet.java
+++ b/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/FeatureSet.java
@@ -435,6 +435,15 @@ final class FeatureSet extends DiscreteSampling {
                 }
             }
         }
+
+        if (coordinates.isEmpty() && trajectory.isEmpty()) {
+            decoder.listeners.warning(decoder.resources().getString(
+                    Resources.Keys.NoSupportedAxisForDimension_2,
+                    featureName, decoder.getFilename()
+            ));
+            return;
+        }
+
         /*
          * Choose whether coordinates are taken in static or dynamic properties. Current implementation does not
          * support mixing both modes (e.g. X and Y coordinates as static properties and T as dynamic property).

--- a/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/Resources.java
+++ b/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/Resources.java
@@ -163,6 +163,11 @@ public final class Resources extends IndexedResourceBundle {
         public static final short MissingVariableAttribute_3 = 23;
 
         /**
+         * Cannot find any valid axis for dimension {0} in file {1}.
+         */
+        public static final short NoSupportedAxisForDimension_2 = 27;
+
+        /**
          * Variable “{1}” or netCDF file “{0}” has a different size than its coordinate system, but no
          * resampling interval is specified.
          */

--- a/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/Resources.properties
+++ b/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/Resources.properties
@@ -45,3 +45,4 @@ UnexpectedDimensionForVariable_4  = Variable \u201c{1}\u201d in file \u201c{0}\u
 UnknownProjectionParameters_2     = Unknown projection parameters in file \u201c{0}\u201d: {1}
 UnmappedDimensions_4              = Variable \u201c{1}\u201d in file \u201c{0}\u201d has {2,number} dimensions but only {3,number} can be associated to a coordinate reference system.
 UnsupportedDataType_3             = NetCDF file \u201c{0}\u201d uses unsupported data type {2} for variable \u201c{1}\u201d.
+NoSupportedAxisForDimension_2     = Cannot find any valid axis for dimension {0} in file {1}.

--- a/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/Resources_fr.properties
+++ b/storage/sis-netcdf/src/main/java/org/apache/sis/internal/netcdf/Resources_fr.properties
@@ -50,3 +50,4 @@ UnexpectedDimensionForVariable_4  = La variable \u00ab\u202f{1}\u202f\u00bb dans
 UnknownProjectionParameters_2     = Param\u00e8tres de projection inconnus dans le fichier \u00ab\u202f{0}\u202f\u00bb\u00a0: {1}
 UnmappedDimensions_4              = La variable \u00ab\u202f{1}\u202f\u00bb dans le fichier \u00ab\u202f{0}\u202f\u00bb a {2,number} dimensions mais seulement {3,number} peuvent \u00eatre associ\u00e9es \u00e0 un syst\u00e8me de r\u00e9f\u00e9rence des coordonn\u00e9es.
 UnsupportedDataType_3             = Le fichier netCDF \u00ab\u202f{0}\u202f\u00bb utilise un type de donn\u00e9es non-support\u00e9 {2} pour la variable \u00ab\u202f{1}\u202f\u00bb.
+NoSupportedAxisForDimension_2     = Aucun axe valide trouvé pour la dimension {0} dans le fichier {1}


### PR DESCRIPTION
I've encountered this error in a project (not able to provide sample file at the moment):

```logs
Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
	at org.apache.sis.internal.netcdf.FeatureSet$Iter.tryAdvance(FeatureSet.java:851)
```

From my understanding, decoder has failed to detect spatio-temporal axes. However, it still attempted to create a spatial dataset.

*Note*: I'm **not** fully sure of my fix. I've decided to ignore the target dimension. Maybe I should have allowed creation of a feature set, but add security to avoid errors later and provide non georeferenced records.

Any advice appreciated.