### PR TITLE
Add GeoAPI-SNAPSHOT as a submodule linking to OGC repository.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "geoapi/snapshot"]
+	path = geoapi/snapshot
+	url = https://github.com/opengeospatial/geoapi
+	shallow = true

--- a/endorsed/build.gradle.kts
+++ b/endorsed/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
  */
 var srcDir = file("src")            // Must be the same as the hard-coded value in `BuildHelper.java`.
 tasks.compileJava {
+    dependsOn(":geoapi:rebuild")
     options.release.set(11)         // The version of both Java source code and compiled byte code.
 }
 tasks.compileTestJava {

--- a/geoapi/README.md
+++ b/geoapi/README.md
@@ -1,0 +1,32 @@
+# GeoAPI snapshot
+
+The Apache SIS source code repository has two branches, named `geoapi-3.1` and `geoapi-4.0`,
+which depend on [GeoAPI](https://www.geoapi.org/) versions that are still in development.
+Those GeoAPI versions are not deployed on Maven Central, because they are not yet officially approved OGC releases.
+The Apache SIS branches that use those versions are never deployed on Maven Central neither.
+Official Apache SIS releases are made from the `master` branch, which depends on the standard GeoAPI 3.0.2 release only.
+
+The Apache SIS `geoapi-3.1` and `geoapi-4.0` branches are nevertheless useful for testing latest GeoAPI developments.
+The implementation experience gained is used for adjusting the GeoAPI interfaces before submission as an OGC standard.
+For making possible to compile against GeoAPI 3.1/4.0 without deployment on Maven Central, GeoAPI must be compiled locally.
+This is done in this directory with a Git sub-module, which fetch GeoAPI at a specific commit identified by a SHA1.
+The commit SHA1 is updated when needed for keeping Apache SIS `geoapi-xxx` branches in sync with the GeoAPI snapshot they implement.
+
+## Git commands
+Following command should be executed once after a fresh checkout of SIS `geoapi-3.1` or `geoapi-4.0` branch:
+
+```bash
+git submodule update --init --recommend-shallow
+```
+
+Following command should be used for pulling changes from Apache SIS Git repository.
+The `--recurse-submodules` option pulls changes in the GeoAPI submodule as well,
+which is necessary for keeping the Apache SIS code in sync with the GeoAPI snapshot that it implements:
+
+```bash
+git pull --recurse-submodules
+```
+
+## Prerequites
+Maven must be available on the classpath.
+The GeoAPI snapshot is built by a call to `mvn clean install`.

--- a/geoapi/build.gradle.kts
+++ b/geoapi/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+tasks.register<Exec>("rebuild") {
+    setWorkingDir(file("snapshot"))
+    commandLine("mvn", "clean", "install")
+    /*
+     * The following are used by Gradle for deciding if the GeoAPI project needs to be rebuilt.
+     * We declare only the modules of interest to Apache SIS. Changes in other modules will not
+     * trigger a rebuild.
+     */
+    inputs.dir("snapshot/geoapi/src/main")
+    inputs.dir("snapshot/geoapi-pending/src/main")
+    inputs.dir("snapshot/geoapi-conformance/src/main")
+
+    outputs.file("snapshot/geoapi-pending/target/geoapi-pending-4.0-SNAPSHOT.jar")
+    outputs.file("snapshot/geoapi-conformance/target/geoapi-conformance-4.0-SNAPSHOT.jar")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ val geoapiVersion = "4.0-SNAPSHOT"
  * The sub-projects to include in the build.
  * They are directory names relative to this file.
  */
+include("geoapi")
 include("endorsed")
 include("incubator")
 if (System.getenv("PATH_TO_FX") != null) {


### PR DESCRIPTION
Add Gradle configuration for building that GeoAPI with Maven. It shall be used only for SIS "geoapi-4.0" and "geoapi-3.1" development branches. The master branch of SIS shall use the official GeoAPI release from Maven Central.